### PR TITLE
Recommend tighter AWS IAM policy to access S3

### DIFF
--- a/onpremises/07-data-storage.md
+++ b/onpremises/07-data-storage.md
@@ -20,7 +20,31 @@ Alternatively, Amazon Web Services S3 (or an S3 compatible service) can be used 
 The basic steps to configure S3 are:
 
 - Create a bucket under your AWS account (folders named `workspaces` and `reviews` will be created in this bucket).
-- Create a new programmatic access user in AWS, with the following permissions: `AmazonS3FullAccess`.
+- Create a new programmatic access user in AWS, with the following IAM policy - make sure to replace the bucket name: 
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Resource": "arn:aws:s3:::BUCKET_NAME"
+        },
+        {
+            "Effect": "Allow",
+            "NotAction": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket"
+            ],
+            "Resource": "arn:aws:s3:::BUCKET_NAME/*"
+        }
+    ]
+}
+```
+
 - Modify your `structurizr.properties` file to configure AWS S3 integration as follows:
 
 | Property name            | Property value                                                                                                                                 |


### PR DESCRIPTION
Hey,

Using the `AmazonS3FullAccess` managed IAM policy is currently advised by the docs in order to access S3.

Since the on-premise installation only requires access to one bucket, I don't think this is ideal.

I found a more restricted set of permissions after running a few tests, which should be sufficient to read and write data.

Although I was unable to locate the actual API calls made to S3, I am happy to further refine the policy.