### PR TITLE
fix: corrects url link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:3
 
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8

--- a/ui/diagrams/code-view.md
+++ b/ui/diagrams/code-view.md
@@ -20,5 +20,5 @@ relational data models, etc. This is not feasible or desirable because:
 - Many IDEs can generate UML class diagrams from existing code.
 - Many database tools can generate entity relationship diagrams from existing database schemas.
 
-Structurizr does support a feature called [image views](/ui/diagrams/image-views) though, which provides a way to
+Structurizr does support a feature called [image views](/ui/diagrams/image-view) though, which provides a way to
 include arbitrary PNG/SVG images in your workspace, and these can function as zoom-ins for level 4.


### PR DESCRIPTION
Hello,

I found a broken link (404) at https://docs.structurizr.com/ui/diagrams/image-views because of the "s" at the end of URL.