### PR TITLE
docs(docker): Add ID mapping to docker commands

### DIFF
--- a/lite/01-quickstart.md
+++ b/lite/01-quickstart.md
@@ -22,14 +22,14 @@ You can now start Structurizr Lite with the following commands, replacing `PATH`
 
 ```
 docker pull structurizr/lite
-docker run -it --rm -p 8080:8080 -v PATH:/usr/local/structurizr structurizr/lite
+docker run -it --rm -p 8080:8080 -u $(id -u):$(id -g) -v PATH:/usr/local/structurizr structurizr/lite
 ```
 
 For example, if your Structurizr data directory is located at `/Users/simon/structurizr`, the command would be:
 
 ```
 docker pull structurizr/lite
-docker run -it --rm -p 8080:8080 -v /Users/simon/structurizr:/usr/local/structurizr structurizr/lite
+docker run -it --rm -p 8080:8080 -i $(id -u):$(id -g) -v /Users/simon/structurizr:/usr/local/structurizr structurizr/lite
 ```
 
 ## 3. Open your web browser


### PR DESCRIPTION
Without this, the workspace files are created with uid/gid 0 and thus belong to "root". They can then not be edited by the user who invoked the docker command in the first place.